### PR TITLE
feat: ✨ add stats comparasion sugestion feature

### DIFF
--- a/src/routes/About.jsx
+++ b/src/routes/About.jsx
@@ -21,6 +21,10 @@ export default function About() {
             <h2 className="mb-2 text-xl text-zinc-100">🤖 Ai generation</h2>
             <p>Still in progress...</p>
           </div>
+          <div className="rounded-xl bg-zinc-800 p-6">
+            <h2 className="mb-2 text-xl text-zinc-100">📊 Stats Comparison</h2>
+            <p>Still in progress...</p>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Hello, Mark!

My name is Atilio Hector. I added a suggestion for a possible feature that I believe will be incredible for the application! By the way, congratulations on her. I've already forked it and will continue contributing to it! :)

The idea is for users to compare the stats of two or more Pokémon side by side, including attributes such as attack, defense and speed.

In other words, the user chooses two Pokémon, and will be able to look at their attributes, side by side, as a comparison, just like those old Pokémon games!

Below is an impression of what it looked like inside the application:

<img width="1080" alt="Captura de Tela 2024-11-20 às 10 55 21" src="https://github.com/user-attachments/assets/bd894d59-ffcb-4a66-a1ca-3ff1e37124fd">

🧪 I did not added unit tests.
